### PR TITLE
add support for react components in circle displayText

### DIFF
--- a/src/ReactBubbleChartD3.js
+++ b/src/ReactBubbleChartD3.js
@@ -15,6 +15,7 @@
 //------------------------------------------------------------------------------
 
 import d3 from 'd3';
+import ReactDOM from 'react-dom';
 
 /**
  * Properties defined during construction:
@@ -268,7 +269,7 @@ export default class ReactBubbleChartD3 {
         .attr('r', d => d.r)
         .style('opacity', 1);
       // intialize new labels
-      labels.enter().append('div')
+      var newLabels = labels.enter().append('div')
         .attr('class', d => {
           var size;
           if (2*d.r < this.smallDiameter) size = 'small';
@@ -276,7 +277,6 @@ export default class ReactBubbleChartD3 {
           else size = 'large';
           return 'bubble-label ' + size
         })
-        .text(d => d.displayText || d._id)
         .on('click', (d, i) => {d3.event.stopPropagation(); props.onClick(d)})
         .on('mouseover', this._tooltipMouseOver.bind(this, color, el))
         .on('mouseout', this._tooltipMouseOut.bind(this))
@@ -286,11 +286,20 @@ export default class ReactBubbleChartD3 {
         .style('left', d =>  d.x - d.r + 'px')
         .style('top', d =>  d.y - d.r + 'px')
         .style('color', d => d.selected ? this.selectedTextColor : textColor(d.colorValue))
-        .style('opacity', 0)
-        .transition()
+        .style('opacity', 0);
+
+      newLabels.transition()
         .duration(duration * 1.2)
         .style('opacity', 1)
         .style('font-size', d => fontFactor ? fontFactor *  d.r + 'px' : null);
+
+      newLabels.each(function(d){
+        if (typeof d.displayText === 'object') {
+          ReactDOM.render(d.displayText, this);
+        } else {
+          d3.select(this).text(d.displayText);
+        }
+      });
     }
 
     // exit - only applies to... exiting elements

--- a/src/ReactBubbleChartD3.js
+++ b/src/ReactBubbleChartD3.js
@@ -269,13 +269,20 @@ export default class ReactBubbleChartD3 {
         .attr('r', d => d.r)
         .style('opacity', 1);
       // intialize new labels
-      var newLabels = labels.enter().append('div')
+      labels.enter().append('div')
         .attr('class', d => {
           var size;
           if (2*d.r < this.smallDiameter) size = 'small';
           else if (2*d.r < this.mediumDiameter) size = 'medium';
           else size = 'large';
           return 'bubble-label ' + size
+        })
+        .each(function(d){
+          if (typeof d.displayText === 'object') {
+            ReactDOM.render(d.displayText, this);
+          } else {
+            d3.select(this).text(d.displayText);
+          }
         })
         .on('click', (d, i) => {d3.event.stopPropagation(); props.onClick(d)})
         .on('mouseover', this._tooltipMouseOver.bind(this, color, el))
@@ -286,20 +293,12 @@ export default class ReactBubbleChartD3 {
         .style('left', d =>  d.x - d.r + 'px')
         .style('top', d =>  d.y - d.r + 'px')
         .style('color', d => d.selected ? this.selectedTextColor : textColor(d.colorValue))
-        .style('opacity', 0);
-
-      newLabels.transition()
+        .style('opacity', 0)
+        .transition()
         .duration(duration * 1.2)
         .style('opacity', 1)
         .style('font-size', d => fontFactor ? fontFactor *  d.r + 'px' : null);
 
-      newLabels.each(function(d){
-        if (typeof d.displayText === 'object') {
-          ReactDOM.render(d.displayText, this);
-        } else {
-          d3.select(this).text(d.displayText);
-        }
-      });
     }
 
     // exit - only applies to... exiting elements

--- a/src/ReactBubbleChartD3.js
+++ b/src/ReactBubbleChartD3.js
@@ -298,7 +298,6 @@ export default class ReactBubbleChartD3 {
         .duration(duration * 1.2)
         .style('opacity', 1)
         .style('font-size', d => fontFactor ? fontFactor *  d.r + 'px' : null);
-
     }
 
     // exit - only applies to... exiting elements

--- a/src/ReactBubbleChartD3.js
+++ b/src/ReactBubbleChartD3.js
@@ -281,7 +281,7 @@ export default class ReactBubbleChartD3 {
           if (typeof d.displayText === 'object') {
             ReactDOM.render(d.displayText, this);
           } else {
-            d3.select(this).text(d.displayText);
+            d3.select(this).text(() => d.displayText || d._id);
           }
         })
         .on('click', (d, i) => {d3.event.stopPropagation(); props.onClick(d)})


### PR DESCRIPTION
This is completely compatible with the existing behavior. The only difference is when the `displayText` of a circle is an object, it will use react to mount that object.  Otherwise it will behave as before and set the circles text to `displayText` or `d._id`.
