### PR TITLE
support a React component in place of displayText for more render flexibility

### DIFF
--- a/src/ReactBubbleChart.js
+++ b/src/ReactBubbleChart.js
@@ -23,11 +23,12 @@ import ReactDOM           from 'react-dom';
 // data format:
 // An array of data objects (defined below) used to populate the bubble chart.
 // {
-//    _id: string,        // unique id (required)
-//    value: number,      // used to determine relative size of bubbles (required)
-//    displayText: string,// will use _id if undefined
-//    colorValue: number, // used to determine color
-//    selected: boolean,  // if true will use selectedColor/selectedTextColor for circle/text
+//    _id: string,                      // unique id (required)
+//    value: number,                    // used to determine relative size of bubbles (required)
+//    innerComponent: React component,  // will use displayText if undefined
+//    displayText: string,              // will use _id if undefined
+//    colorValue: number,               // used to determine color
+//    selected: boolean,                // if true will use selectedColor/selectedTextColor for circle/text
 // }
 //
 // Can also be a nested JSON object if you want a nested bubble chart. That would look like:

--- a/src/ReactBubbleChartD3.js
+++ b/src/ReactBubbleChartD3.js
@@ -15,6 +15,7 @@
 //------------------------------------------------------------------------------
 
 import d3 from 'd3';
+import { renderToString } from 'react-dom/server';
 
 /**
  * Properties defined during construction:
@@ -276,8 +277,13 @@ export default class ReactBubbleChartD3 {
           else size = 'large';
           return 'bubble-label ' + size
         })
-        .text(d => d.displayText || d._id)
         .on('click', (d, i) => {d3.event.stopPropagation(); props.onClick(d)})
+        .html(({ innerComponent, ...d }) => {
+          if (innerComponent) {
+            return renderToString(innerComponent(d));
+          }
+          return d.displayText || d._id;
+        })
         .on('mouseover', this._tooltipMouseOver.bind(this, color, el))
         .on('mouseout', this._tooltipMouseOut.bind(this))
         .style('position', 'absolute')


### PR DESCRIPTION
This follows suggestions in https://github.com/kauffecup/react-bubble-chart/pull/5 to allow passing a React component in place of `props.displayText`.
If not supplied, `displayText` will be used or fallback to `_id` as per current behaviour.